### PR TITLE
修复文件夹命名的问题

### DIFF
--- a/js/core/tmplink.js
+++ b/js/core/tmplink.js
@@ -2208,6 +2208,9 @@ class tmplink {
 
     mr_newname(mrid) {
         var newname = prompt(this.languageData.modal_meetingroom_newname, "");
+        if(newname===null){
+            return false;
+        }
         $.post(this.api_mr, {
             action: 'rename',
             token: this.api_token,


### PR DESCRIPTION
修改文件夹命名时，如果取消了弹出窗口，文件夹的名字会被设置为 N/A。
不符合预期。