### PR TITLE
修复昵称或介绍为空时错误的提示

### DIFF
--- a/js/core/profile.js
+++ b/js/core/profile.js
@@ -96,7 +96,7 @@ class profile {
         let userTitle = $('#userinfo_name_input').val();
         let userIntro = $('#userinfo_intro_input').val();
         if (userTitle == '' || userIntro == '') {
-            alert(app.languageData.direct_user_name_empty);
+            alert(app.languageData.direct_brand_name_empty);
             return false;
         }
         $.post(this.parent_op.api_user, {

--- a/json/cn.json
+++ b/json/cn.json
@@ -610,7 +610,7 @@
     "direct_brand_logo_set_invalid":"无效的图片",
     "direct_brand_logo_set_size":"图片大小超过限制",
     "direct_brand_logo_set_unknow":"网络错误，请重试",
-    "direct_brand_name_empty":"名称于描述不能为空",
+    "direct_brand_name_empty":"名称与描述不能为空",
 
     "brand_submit":"提交审核",
     "brand_save":"保存",

--- a/json/hk.json
+++ b/json/hk.json
@@ -39,7 +39,7 @@
     "direct_brand_logo_set_invalid": "無效的圖片",
     "direct_brand_logo_set_size": "圖片大小超過限制",
     "direct_brand_logo_set_unknow": "網絡錯誤，請重試",
-    "direct_brand_name_empty": "名稱於描述不能為空",
+    "direct_brand_name_empty": "名稱與描述不能為空",
     "brand_submit": "提交審核",
     "brand_save": "保存",
     "brand_modal_title": "品牌化",


### PR DESCRIPTION
## bug复现方式
登录钛盘，点击设置-个性化，只填写昵称或介绍（或者都不写），点击保存
理论上所有浏览器可复现，原因在[这里](https://github.com/tmplink/tmplink_webapp/commit/59d0b0072f6cfdf05810c2792933712eb854ed7f#diff-20799e9d3750496ba2f04220648b6154a3c76c2750084a8eddd27bf0dcf5103eR99)
![6%(N255J4R3~WGM~$)V@ 7N](https://user-images.githubusercontent.com/62790279/210921086-8c69f474-5b01-45b8-8aec-61d25aba0f65.png)
## 修复内容
- 修复了提示 undefined 的问题
- 修复了语言文件里的拼写错误，日语看不懂所以没动，机翻了一下好像是没问题，简体中文和繁体中文都出错了
